### PR TITLE
Update ion-rating.component.ts

### DIFF
--- a/projects/ionic-rating/src/lib/ion-rating.component.ts
+++ b/projects/ionic-rating/src/lib/ion-rating.component.ts
@@ -29,7 +29,7 @@ export class IonRatingComponent implements ControlValueAccessor, OnChanges {
   @Input() rate: number;
   @Input() readonly: boolean;
   @Input() resettable: boolean;
-  @Input() size: boolean;
+  @Input() size: string;
   @Output() hover = new EventEmitter<number>();
   @Output() leave = new EventEmitter<number>();
   @Output() rateChange = new EventEmitter<number>();


### PR DESCRIPTION
the size property is declared as boolean.. whereas the selector shows it as string.